### PR TITLE
Use RoutingMode instead of MainModeIdentifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **1.0.9-dev**
 
+- Use "routing mode" instead of MainModeIdentifier
 - Allow ReRoute strategy in combination with DCM
 - Add TourLengthFilter and document filters
 - BC: Remove over-complicated generics for UtilitySelector/Factory

--- a/src/main/java/ch/ethz/matsim/discrete_mode_choice/replanning/DiscreteModeChoiceAlgorithm.java
+++ b/src/main/java/ch/ethz/matsim/discrete_mode_choice/replanning/DiscreteModeChoiceAlgorithm.java
@@ -9,7 +9,6 @@ import org.matsim.api.core.v01.population.Plan;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.api.core.v01.population.PopulationFactory;
 import org.matsim.core.population.algorithms.PlanAlgorithm;
-import org.matsim.core.router.MainModeIdentifier;
 import org.matsim.core.router.TripRouter;
 
 import ch.ethz.matsim.discrete_mode_choice.model.DiscreteModeChoiceModel;
@@ -28,14 +27,12 @@ public class DiscreteModeChoiceAlgorithm implements PlanAlgorithm {
 	private final Random random;
 	private final DiscreteModeChoiceModel modeChoiceModel;
 
-	private final MainModeIdentifier mainModeIdentifier;
 	private final PopulationFactory populationFactory;
 
 	public DiscreteModeChoiceAlgorithm(Random random, DiscreteModeChoiceModel modeChoiceModel,
-			MainModeIdentifier mainModeIdentifier, PopulationFactory populationFactory) {
+			PopulationFactory populationFactory) {
 		this.random = random;
 		this.modeChoiceModel = modeChoiceModel;
-		this.mainModeIdentifier = mainModeIdentifier;
 		this.populationFactory = populationFactory;
 	}
 
@@ -46,7 +43,7 @@ public class DiscreteModeChoiceAlgorithm implements PlanAlgorithm {
 	 */
 	public void run(Plan plan) {
 		// I) First build a list of DiscreteModeChoiceTrips
-		List<DiscreteModeChoiceTrip> trips = TripListConverter.convert(plan, mainModeIdentifier);
+		List<DiscreteModeChoiceTrip> trips = TripListConverter.convert(plan);
 
 		// II) Run mode choice
 

--- a/src/main/java/ch/ethz/matsim/discrete_mode_choice/replanning/DiscreteModeChoiceReplanningModule.java
+++ b/src/main/java/ch/ethz/matsim/discrete_mode_choice/replanning/DiscreteModeChoiceReplanningModule.java
@@ -5,8 +5,6 @@ import org.matsim.core.config.groups.GlobalConfigGroup;
 import org.matsim.core.gbl.MatsimRandom;
 import org.matsim.core.population.algorithms.PlanAlgorithm;
 import org.matsim.core.replanning.modules.AbstractMultithreadedModule;
-import org.matsim.core.router.MainModeIdentifier;
-import org.matsim.core.router.TripRouter;
 
 import com.google.inject.Provider;
 
@@ -22,27 +20,19 @@ public class DiscreteModeChoiceReplanningModule extends AbstractMultithreadedMod
 	public static final String NAME = "DiscreteModeChoice";
 
 	final private Provider<DiscreteModeChoiceModel> modelProvider;
-	final private Provider<TripRouter> tripRouterProvider;
 	final private PopulationFactory populationFactory;
-	final private MainModeIdentifier mainModeIdentifier;
 
 	public DiscreteModeChoiceReplanningModule(GlobalConfigGroup globalConfigGroup,
-			Provider<DiscreteModeChoiceModel> modeChoiceModelProvider, Provider<TripRouter> tripRouterProvider,
-			PopulationFactory populationFactory, MainModeIdentifier mainModeIdentifier) {
+			Provider<DiscreteModeChoiceModel> modeChoiceModelProvider, PopulationFactory populationFactory) {
 		super(globalConfigGroup);
 
 		this.modelProvider = modeChoiceModelProvider;
-		this.tripRouterProvider = tripRouterProvider;
 		this.populationFactory = populationFactory;
-		this.mainModeIdentifier = mainModeIdentifier;
 	}
 
 	@Override
 	public PlanAlgorithm getPlanAlgoInstance() {
 		DiscreteModeChoiceModel choiceModel = modelProvider.get();
-		TripRouter tripRouter = tripRouterProvider.get();
-
-		return new DiscreteModeChoiceAlgorithm(MatsimRandom.getLocalInstance(), choiceModel, mainModeIdentifier,
-				populationFactory);
+		return new DiscreteModeChoiceAlgorithm(MatsimRandom.getLocalInstance(), choiceModel, populationFactory);
 	}
 }

--- a/src/main/java/ch/ethz/matsim/discrete_mode_choice/replanning/DiscreteModeChoiceStrategyProvider.java
+++ b/src/main/java/ch/ethz/matsim/discrete_mode_choice/replanning/DiscreteModeChoiceStrategyProvider.java
@@ -9,7 +9,6 @@ import org.matsim.core.replanning.PlanStrategy;
 import org.matsim.core.replanning.PlanStrategyImpl;
 import org.matsim.core.replanning.modules.ReRoute;
 import org.matsim.core.replanning.selectors.RandomPlanSelector;
-import org.matsim.core.router.MainModeIdentifier;
 import org.matsim.core.router.TripRouter;
 import org.matsim.facilities.ActivityFacilities;
 
@@ -39,26 +38,24 @@ public class DiscreteModeChoiceStrategyProvider implements Provider<PlanStrategy
 	private final Provider<DiscreteModeChoiceModel> modeChoiceModelProvider;
 	private final DiscreteModeChoiceConfigGroup dmcConfig;
 	private final PopulationFactory populationFactory;
-	private final MainModeIdentifier mainModeIdentifier;
 
 	@Inject
 	DiscreteModeChoiceStrategyProvider(GlobalConfigGroup globalConfigGroup, ActivityFacilities activityFacilities,
 			Provider<TripRouter> tripRouterProvider, Provider<DiscreteModeChoiceModel> modeChoiceModelProvider,
-			DiscreteModeChoiceConfigGroup dmcConfig, Population population, MainModeIdentifier mainModeIdentifier) {
+			DiscreteModeChoiceConfigGroup dmcConfig, Population population) {
 		this.globalConfigGroup = globalConfigGroup;
 		this.activityFacilities = activityFacilities;
 		this.tripRouterProvider = tripRouterProvider;
 		this.modeChoiceModelProvider = modeChoiceModelProvider;
 		this.dmcConfig = dmcConfig;
 		this.populationFactory = population.getFactory();
-		this.mainModeIdentifier = mainModeIdentifier;
 	}
 
 	@Override
 	public PlanStrategy get() {
 		PlanStrategyImpl.Builder builder = new PlanStrategyImpl.Builder(new RandomPlanSelector<>());
-		builder.addStrategyModule(new DiscreteModeChoiceReplanningModule(globalConfigGroup, modeChoiceModelProvider,
-				tripRouterProvider, populationFactory, mainModeIdentifier));
+		builder.addStrategyModule(
+				new DiscreteModeChoiceReplanningModule(globalConfigGroup, modeChoiceModelProvider, populationFactory));
 
 		if (dmcConfig.getPerformReroute()) {
 			builder.addStrategyModule(new ReRoute(activityFacilities, tripRouterProvider, globalConfigGroup));

--- a/src/main/java/ch/ethz/matsim/discrete_mode_choice/replanning/TripListConverter.java
+++ b/src/main/java/ch/ethz/matsim/discrete_mode_choice/replanning/TripListConverter.java
@@ -6,7 +6,6 @@ import java.util.List;
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.population.Activity;
 import org.matsim.api.core.v01.population.Plan;
-import org.matsim.core.router.MainModeIdentifier;
 import org.matsim.core.router.TripStructureUtils;
 import org.matsim.core.router.TripStructureUtils.Trip;
 import org.matsim.core.utils.misc.Time;
@@ -31,7 +30,7 @@ public final class TripListConverter {
 	 * respective legs. It is expected that the plan is already flattened (i.e.
 	 * there are no interaction activities).
 	 */
-	public static List<DiscreteModeChoiceTrip> convert(Plan plan, MainModeIdentifier mainModeIdentifier) {
+	public static List<DiscreteModeChoiceTrip> convert(Plan plan) {
 		List<Trip> initialTrips = TripStructureUtils.getTrips(plan);
 		List<DiscreteModeChoiceTrip> trips = new ArrayList<>(initialTrips.size());
 
@@ -52,7 +51,7 @@ public final class TripListConverter {
 						plan.getPerson().getId().toString(), Time.writeTime(time)));
 			}
 
-			String initialMode = mainModeIdentifier.identifyMainMode(initialTrip.getTripElements());
+			String initialMode = TripStructureUtils.getRoutingMode(initialTrip.getLegsOnly().get(0));
 
 			trips.add(new DiscreteModeChoiceTrip(originActivity, destinationActivity, initialMode,
 					initialTrip.getTripElements(), time, plan.getPerson().hashCode(), index));

--- a/src/test/java/ch/ethz/matsim/discrete_mode_choice/SubtourModeChoiceReplacementTest.java
+++ b/src/test/java/ch/ethz/matsim/discrete_mode_choice/SubtourModeChoiceReplacementTest.java
@@ -15,7 +15,6 @@ import org.matsim.core.population.algorithms.ChooseRandomLegModeForSubtour;
 import org.matsim.core.population.algorithms.PermissibleModesCalculator;
 import org.matsim.core.population.algorithms.PermissibleModesCalculatorImpl;
 import org.matsim.core.replanning.modules.SubtourModeChoice;
-import org.matsim.core.router.MainModeIdentifier;
 import org.matsim.core.router.MainModeIdentifierImpl;
 
 import ch.ethz.matsim.discrete_mode_choice.components.constraints.SubtourModeConstraint;
@@ -37,7 +36,6 @@ import ch.ethz.matsim.discrete_mode_choice.model.mode_availability.ModeAvailabil
 import ch.ethz.matsim.discrete_mode_choice.model.mode_chain.DefaultModeChainGenerator;
 import ch.ethz.matsim.discrete_mode_choice.model.mode_chain.ModeChainGeneratorFactory;
 import ch.ethz.matsim.discrete_mode_choice.model.tour_based.TourBasedModel;
-import ch.ethz.matsim.discrete_mode_choice.model.tour_based.TourCandidate;
 import ch.ethz.matsim.discrete_mode_choice.model.tour_based.TourConstraintFactory;
 import ch.ethz.matsim.discrete_mode_choice.model.tour_based.TourEstimator;
 import ch.ethz.matsim.discrete_mode_choice.model.tour_based.TourFilter;
@@ -364,13 +362,12 @@ public class SubtourModeChoiceReplacementTest {
 		String[] availableModes = modes.toArray(new String[] {});
 		String[] chainBasedModes = constrainedModes.toArray(new String[] {});
 
-		MainModeIdentifier mainModeIdentifier = new MainModeIdentifierImpl();
 		PermissibleModesCalculator permissibleModesCalculator = new PermissibleModesCalculatorImpl(availableModes,
 				considerCarAvailability);
 		Random rng = new Random(0);
 		SubtourModeChoice.Behavior behavior = SubtourModeChoice.Behavior.fromSpecifiedModesToSpecifiedModes;
 
-		ChooseRandomLegModeForSubtour smc = new ChooseRandomLegModeForSubtour(mainModeIdentifier,
+		ChooseRandomLegModeForSubtour smc = new ChooseRandomLegModeForSubtour(new MainModeIdentifierImpl(),
 				permissibleModesCalculator, availableModes, chainBasedModes, rng, behavior, singleLegProbability);
 
 		Set<List<String>> chains = new HashSet<>();

--- a/src/test/java/ch/ethz/matsim/discrete_mode_choice/test_utils/PlanBuilder.java
+++ b/src/test/java/ch/ethz/matsim/discrete_mode_choice/test_utils/PlanBuilder.java
@@ -14,7 +14,6 @@ import org.matsim.api.core.v01.population.PopulationFactory;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.population.PopulationUtils;
-import org.matsim.core.router.MainModeIdentifierImpl;
 import org.matsim.facilities.ActivityFacility;
 
 import ch.ethz.matsim.discrete_mode_choice.model.DiscreteModeChoiceTrip;
@@ -93,6 +92,6 @@ public class PlanBuilder {
 	}
 
 	public List<DiscreteModeChoiceTrip> buildDiscreteModeChoiceTrips() {
-		return TripListConverter.convert(plan, new MainModeIdentifierImpl());
+		return TripListConverter.convert(plan);
 	}
 }


### PR DESCRIPTION
Since MATSim 12w49 the routing mode of a leg should be used instead of MainModeIdentifier. Closes #77.